### PR TITLE
RestDatastoreClient code cleanup

### DIFF
--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/DataMessagesJson.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/DataMessagesJson.java
@@ -202,6 +202,8 @@ public class DataMessagesJson extends AbstractKapuaResource implements JsonSeria
 
         JsonMessageListResult jsonResult = new JsonMessageListResult();
         jsonResult.addItems(jsonDatastoreMessages);
+        jsonResult.setLimitExceeded(result.isLimitExceeded());
+        jsonResult.setTotalCount(result.getTotalCount());
         return jsonResult;
     }
 


### PR DESCRIPTION
This PR does some cleanup on `RestDatastoreClient` introducing lambdas instead of Callables, removing unnecessary type parameters and other minor refactorings